### PR TITLE
Unary minus operator

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import { DEFAULT_TEXT } from "./constants.js";
 const hash = window.location.hash;
 console.log(`loading from hash ${hash}`);
 
-let data;
+let data = {};
 let code;
 let configOpts;
 

--- a/test/transform/dec128.test.js
+++ b/test/transform/dec128.test.js
@@ -39,6 +39,10 @@ const operators = {
     code: "10.3m / 12.4m",
     output: 'Decimal("10.3").div(Decimal("12.4"));',
   },
+  "converts unary - to .neg()": {
+    code: "-10.3m + -12.4m",
+    output: 'Decimal("10.3").neg().add(Decimal("12.4").neg());',
+  },
 };
 
 const nestedOutput = `
@@ -72,6 +76,10 @@ const inBinaryExpressions = {
   "transforms long nested BinaryExpressions": {
     code: "21.3m * (0.4m + 11.3m) - (10m * (10000.m + 90m)) - 80m + 35.67m * 103429.642950m + 21.3m * (0.4m + 11.3m) - 10m * 10000.m + 90m - 80m + 35.67m * 103429.642950m ;",
     output: longNestedOutput,
+  },
+  "transforms negation of expression": {
+    code: "-(0.001m + 17.6m)",
+    output: 'Decimal("0.001").add(Decimal("17.6")).neg();',
   },
 };
 

--- a/transforms/bigdec.js
+++ b/transforms/bigdec.js
@@ -2,6 +2,7 @@ import {
   earlyReturn,
   passesGeneralChecks,
   replaceWithDecimal,
+  replaceWithUnaryDecimalExpression,
   sharedOpts,
 } from "./shared.js";
 
@@ -55,6 +56,9 @@ export default function (babel) {
       },
       CallExpression: addToDecimalNodes(t, knownDecimalNodes),
       DecimalLiteral: replaceWithDecimal(t),
+      UnaryExpression: {
+        exit: replaceWithUnaryDecimalExpression(t, knownDecimalNodes),
+      },
     },
   };
 }

--- a/transforms/dec128.js
+++ b/transforms/dec128.js
@@ -2,6 +2,7 @@ import {
   earlyReturn,
   passesGeneralChecks,
   replaceWithDecimal,
+  replaceWithUnaryDecimalExpression,
   sharedOpts,
 } from "./shared.js";
 
@@ -52,6 +53,9 @@ export default function (babel) {
       },
       CallExpression: addToDecimalNodes(t, knownDecimalNodes),
       DecimalLiteral: replaceWithDecimal(t),
+      UnaryExpression: {
+        exit: replaceWithUnaryDecimalExpression(t, knownDecimalNodes),
+      },
     },
   };
 }

--- a/transforms/shared.js
+++ b/transforms/shared.js
@@ -30,6 +30,27 @@ export const replaceWithDecimal = (t) => (path) => {
   path.replaceWith(t.callExpression(callee, [num]));
 };
 
+export const replaceWithUnaryDecimalExpression = (t, knownDecimalNodes) => (path) => {
+  const { argument, operator } = path.node;
+
+  if (!knownDecimalNodes.has(argument)) {
+    return;
+  }
+
+  if (operator !== "-") {
+    throw path.buildCodeFrameError(
+      new SyntaxError(`${operator} is not currently supported.`));
+  }
+
+  const member = t.memberExpression(argument, t.identifier("neg"));
+  const newNode = t.callExpression(member, []);
+
+  knownDecimalNodes.add(newNode);
+
+  path.replaceWith(newNode);
+  path.skip();
+};
+
 export const sharedOpts = {
   "+": "add",
   "*": "mul",


### PR DESCRIPTION
Unary minus corresponds to decimal.js's `.neg()` method. Leaves other unary operators unimplemented for now.

Also includes a small fix for loading the website without a hash in the URL — otherwise I got a blank page.