### PR TITLE
Implement some Math functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,8 @@
       "devDependencies": {
         "@babel/plugin-transform-modules-commonjs": "^7.16.5",
         "babel-plugin-tester": "^10.1.0",
+        "big.js": "6.1.1",
+        "decimal.js": "10.3.1",
         "eslint": "^8.5.0",
         "eslint-config-prettier": "^8.3.0",
         "jest": "^27.4.5",
@@ -3479,11 +3481,16 @@
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
     },
     "node_modules/big.js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.1.1.tgz",
+      "integrity": "sha512-1vObw81a8ylZO5ePrtMay0n018TcftpTA5HFKDaSuiUDBo8biRBtjIobw60OpwuvrGk+FsxKamqN4cnmj/eXdg==",
+      "dev": true,
       "engines": {
         "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bigjs"
       }
     },
     "node_modules/binary-extensions": {
@@ -8513,6 +8520,14 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/loader-utils/node_modules/big.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/loader-utils/node_modules/json5": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
@@ -8794,6 +8809,14 @@
       "peerDependencies": {
         "monaco-editor": ">= 0.31.0",
         "webpack": "^4.5.0 || 5.x"
+      }
+    },
+    "node_modules/monaco-editor-webpack-plugin/node_modules/big.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/monaco-editor-webpack-plugin/node_modules/loader-utils": {
@@ -14275,9 +14298,10 @@
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
     },
     "big.js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.1.1.tgz",
+      "integrity": "sha512-1vObw81a8ylZO5ePrtMay0n018TcftpTA5HFKDaSuiUDBo8biRBtjIobw60OpwuvrGk+FsxKamqN4cnmj/eXdg==",
+      "dev": true
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -18058,6 +18082,11 @@
         "json5": "^1.0.1"
       },
       "dependencies": {
+        "big.js": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+          "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+        },
         "json5": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
@@ -18281,6 +18310,11 @@
         "loader-utils": "^2.0.2"
       },
       "dependencies": {
+        "big.js": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+          "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+        },
         "loader-utils": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
   "devDependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.16.5",
     "babel-plugin-tester": "^10.1.0",
+    "big.js": "6.1.1",
+    "decimal.js": "10.3.1",
     "eslint": "^8.5.0",
     "eslint-config-prettier": "^8.3.0",
     "jest": "^27.4.5",

--- a/src/constants.js
+++ b/src/constants.js
@@ -44,6 +44,7 @@ const EDITOR = "Editor";
 const OUTPUT = "Output";
 const THREE_UP = "columns";
 const CHECKERBOARD = "checkerboard";
+// Keep in sync with src/runner/patches.js
 const BIG_DECIMAL = "big decimal";
 const DECIMAL_128 = "decimal 128";
 

--- a/src/runner/index.html
+++ b/src/runner/index.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8" />
     <script src="https://unpkg.com/decimal.js@10.3.1/decimal.js"></script>
     <script src="https://unpkg.com/big.js@6.1.1/big.js"></script>
+    <script src="./patches.js"></script>
     <script src="./index.js"></script>
   </head>
 </html>

--- a/src/runner/patches.js
+++ b/src/runner/patches.js
@@ -1,0 +1,49 @@
+/* global Big, Decimal */
+
+const DEC_128 = "decimal128";
+const BIG_DECIMAL = "bigdec";
+
+const createUnaryHandler = (substituteFns) => ({
+  apply(target, thisArg, argsList) {
+    const [arg] = argsList;
+    if (arg instanceof Decimal) {
+      return substituteFns[DEC_128](arg);
+    }
+
+    if (arg instanceof Big) {
+      return substituteFns[BIG_DECIMAL](arg);
+    }
+
+    return target.apply(thisArg, argsList);
+  },
+});
+
+// A few functions can take mixed values (max, min, pow)
+// The refiner can be used to apply more careful rules about mixing
+const createNaryHandler = (substituteFns, refiner = () => true) => ({
+  apply(target, thisArg, argsList) {
+    const containsDecimals = argsList.some(
+      (arg) => arg instanceof Decimal || arg instanceof Big
+    );
+
+    if (!containsDecimals) {
+      return target.apply(thisArg, argsList);
+    }
+
+    if (!refiner(argsList)) {
+      throw new TypeError(
+        `types mixed in this fashion not supported in Math.${target.name}`
+      );
+    }
+
+    // We assume that the args are not mixed decimal versions
+    // because if they are other things have gone very badly
+    if (argsList[0] instanceof Decimal) {
+      return substituteFns[DEC_128](...argsList);
+    }
+
+    if (argsList[0] instanceof Big) {
+      return substituteFns[BIG_DECIMAL](...argsList);
+    }
+  },
+});

--- a/src/runner/patches.js
+++ b/src/runner/patches.js
@@ -1,13 +1,14 @@
 /* global Big, Decimal */
 
-const DEC_128 = "decimal128";
-const BIG_DECIMAL = "bigdec";
+// Keep in sync with src/constants.js
+const BIG_DECIMAL = "big decimal";
+const DECIMAL_128 = "decimal 128";
 
 const createUnaryHandler = (substituteFns) => ({
   apply(target, thisArg, argsList) {
     const [arg] = argsList;
     if (arg instanceof Decimal) {
-      return substituteFns[DEC_128](arg);
+      return substituteFns[DECIMAL_128](arg);
     }
 
     if (arg instanceof Big) {
@@ -39,7 +40,7 @@ const createNaryHandler = (substituteFns, refiner = () => true) => ({
     // We assume that the args are not mixed decimal versions
     // because if they are other things have gone very badly
     if (argsList[0] instanceof Decimal) {
-      return substituteFns[DEC_128](...argsList);
+      return substituteFns[DECIMAL_128](...argsList);
     }
 
     if (argsList[0] instanceof Big) {

--- a/test/src/runner/patches-128.test.js
+++ b/test/src/runner/patches-128.test.js
@@ -1,0 +1,69 @@
+import { beforeAll, describe, expect, it } from "@jest/globals";
+import Big from "big.js";
+globalThis.Big = Big;
+import Decimal from "decimal.js";
+globalThis.Decimal = Decimal;
+
+describe("Runtime tests for Decimal128", function () {
+  beforeAll(function () {
+    Decimal.set({ precision: 34 });
+    return import("../../../src/runner/patches.js");
+  });
+
+  describe("Math.abs", function () {
+    it("handles decimal", function () {
+      expect(Math.abs(Decimal("-1.5"))).toEqual(Decimal("1.5"));
+      expect(Math.abs(Decimal("1.5"))).toEqual(Decimal("1.5"));
+      expect(Math.abs(Decimal("0"))).toEqual(Decimal("0"));
+    });
+
+    it("still handles non-decimal", function () {
+      expect(Math.abs(-1.5)).toEqual(1.5);
+      expect(Math.abs(1.5)).toEqual(1.5);
+      expect(Math.abs(0)).toEqual(0);
+    });
+  });
+
+  describe("Math.floor", function () {
+    it("handles decimal", function () {
+      expect(Math.floor(Decimal("-1.5"))).toEqual(Decimal("-2"));
+      expect(Math.floor(Decimal("1.5"))).toEqual(Decimal("1"));
+    });
+
+    it("still handles non-decimal", function () {
+      expect(Math.floor(-1.5)).toEqual(-2);
+      expect(Math.floor(1.5)).toEqual(1);
+    });
+  });
+
+  describe("Math.log10", function () {
+    it("handles decimal", function () {
+      expect(Math.log10(Decimal("1000"))).toEqual(Decimal("3"));
+      expect(Math.log10(Decimal(".001"))).toEqual(Decimal("-3"));
+    });
+
+    it("still handles non-decimal", function () {
+      expect(Math.log10(1000)).toEqual(3);
+      expect(Math.log10(0.001)).toBeCloseTo(-3);
+    });
+  });
+
+  describe("Math.pow", function () {
+    it("handles both arguments decimal", function () {
+      expect(Math.pow(Decimal("1.01"), Decimal("12"))).toEqual(
+        Decimal("1.126825030131969720661201")
+      );
+    });
+
+    it("still handles both arguments non-decimal", function () {
+      expect(Math.pow(1.01, 12)).toBeCloseTo(
+        Number("1.126825030131969720661201")
+      );
+    });
+
+    it("throws on mixed arguments", function () {
+      expect(() => Math.pow(Decimal("1.01"), 12)).toThrow(TypeError);
+      expect(() => Math.pow(1.01, Decimal("12"))).toThrow(TypeError);
+    });
+  });
+});

--- a/test/src/runner/patches-big.test.js
+++ b/test/src/runner/patches-big.test.js
@@ -1,0 +1,68 @@
+import { beforeAll, describe, expect, it } from "@jest/globals";
+import Big from "big.js";
+globalThis.Big = Big;
+import Decimal from "decimal.js";
+globalThis.Decimal = Decimal;
+
+describe("Runtime tests for BigDecimal", function () {
+  beforeAll(function () {
+    return import("../../../src/runner/patches.js");
+  });
+
+  describe("Math.abs", function () {
+    it("handles decimal", function () {
+      expect(Math.abs(Big("-1.5"))).toEqual(Big("1.5"));
+      expect(Math.abs(Big("1.5"))).toEqual(Big("1.5"));
+      expect(Math.abs(Big("0"))).toEqual(Big("0"));
+    });
+
+    it("still handles non-decimal", function () {
+      expect(Math.abs(-1.5)).toEqual(1.5);
+      expect(Math.abs(1.5)).toEqual(1.5);
+      expect(Math.abs(0)).toEqual(0);
+    });
+  });
+
+  describe("Math.floor", function () {
+    it("handles decimal", function () {
+      expect(Math.floor(Big("-1.5"))).toEqual(Big("-2"));
+      expect(Math.floor(Big("1.5"))).toEqual(Big("1"));
+    });
+
+    it("still handles non-decimal", function () {
+      expect(Math.floor(-1.5)).toEqual(-2);
+      expect(Math.floor(1.5)).toEqual(1);
+    });
+  });
+
+  describe("Math.log10", function () {
+    it.skip("handles decimal", function () {
+      expect(Math.log10(Big("1000"))).toEqual(Big("3"));
+      expect(Math.log10(Big(".001"))).toEqual(Big("-3"));
+    });
+
+    it("still handles non-decimal", function () {
+      expect(Math.log10(1000)).toEqual(3);
+      expect(Math.log10(0.001)).toBeCloseTo(-3);
+    });
+  });
+
+  describe("Math.pow", function () {
+    it("handles both arguments decimal", function () {
+      expect(Math.pow(Big("1.01"), Big("12"))).toEqual(
+        Big("1.126825030131969720661201")
+      );
+    });
+
+    it("still handles both arguments non-decimal", function () {
+      expect(Math.pow(1.01, 12)).toBeCloseTo(
+        Number("1.126825030131969720661201")
+      );
+    });
+
+    it("throws on mixed arguments", function () {
+      expect(() => Math.pow(Big("1.01"), 12)).toThrow(TypeError);
+      expect(() => Math.pow(1.01, Big("12"))).toThrow(TypeError);
+    });
+  });
+});

--- a/test/transforms/bigdec.test.js
+++ b/test/transforms/bigdec.test.js
@@ -86,6 +86,29 @@ const inFunctions = {
   },
 };
 
+const withKnownDecimalInputs = {
+  "unary Math method with known decimal input is known to be decimal": {
+    code: "-Math.abs(-1.5m);",
+    output: `Math.abs(${libName}("1.5").neg()).neg();`,
+  },
+  "unary Math method with known non-decimal input is not transformed": {
+    code: "-Math.abs(-1.5);",
+    output: "-Math.abs(-1.5);",
+  },
+  "n-ary Math method with known decimal inputs is known to be decimal": {
+    code: "-Math.pow(1.01m, 12m);",
+    output: `Math.pow(${libName}("1.01"), ${libName}("12")).neg();`,
+  },
+  "n-ary Math method with known non-decimal inputs is not transformed": {
+    code: "-Math.pow(1.01, 12);",
+    output: "-Math.pow(1.01, 12);",
+  },
+  "n-ary math method with mixed inputs is not transformed": {
+    code: "-Math.pow(1.01m, 12);",
+    output: `-Math.pow(${libName}("1.01"), 12);`,
+  },
+};
+
 pluginTester({
   plugin: pluginBigDec,
   pluginName: "plugin-big-decimal",
@@ -95,5 +118,6 @@ pluginTester({
     ...inBinaryExpressions,
     ...inFunctions,
     ...doesNotChangeNumbers,
+    ...withKnownDecimalInputs,
   },
 });

--- a/test/transforms/bigdec.test.js
+++ b/test/transforms/bigdec.test.js
@@ -1,7 +1,7 @@
 import pluginTester from "babel-plugin-tester";
 import pluginBigDec from "../../transforms/bigdec.js";
 
-const libName = 'Big';
+const libName = "Big";
 
 const basic = {
   "transforms literal": {

--- a/test/transforms/dec128.test.js
+++ b/test/transforms/dec128.test.js
@@ -90,6 +90,29 @@ const inFunctions = {
   },
 };
 
+const withKnownDecimalInputs = {
+  "unary Math method with known decimal input is known to be decimal": {
+    code: "-Math.abs(-1.5m);",
+    output: 'Math.abs(Decimal("1.5").neg()).neg();',
+  },
+  "unary Math method with known non-decimal input is not transformed": {
+    code: "-Math.abs(-1.5);",
+    output: "-Math.abs(-1.5);",
+  },
+  "n-ary Math method with known decimal inputs is known to be decimal": {
+    code: "-Math.pow(1.01m, 12m);",
+    output: 'Math.pow(Decimal("1.01"), Decimal("12")).neg();',
+  },
+  "n-ary Math method with known non-decimal inputs is not transformed": {
+    code: "-Math.pow(1.01, 12);",
+    output: "-Math.pow(1.01, 12);",
+  },
+  "n-ary math method with mixed inputs is not transformed": {
+    code: "-Math.pow(1.01m, 12);",
+    output: '-Math.pow(Decimal("1.01"), 12);',
+  },
+};
+
 pluginTester({
   plugin: pluginDec128,
   pluginName: "plugin-decimal-128",
@@ -99,5 +122,6 @@ pluginTester({
     ...inBinaryExpressions,
     ...inFunctions,
     ...doesNotChangeNumbers,
+    ...withKnownDecimalInputs,
   },
 });

--- a/transforms/bigdec.js
+++ b/transforms/bigdec.js
@@ -1,9 +1,11 @@
 import {
   earlyReturn,
+  isMathMethod,
   passesGeneralChecks,
   replaceWithDecimal,
   replaceWithUnaryDecimalExpression,
   sharedOpts,
+  supportedMathMethods,
 } from "./shared.js";
 
 const implementationIdentifier = "Big";
@@ -35,8 +37,18 @@ const replaceWithDecimalExpression = (t, knownDecimalNodes) => (path) => {
 };
 
 const addToDecimalNodes = (t, knownDecimalNodes) => (path) => {
-  if (path.get("callee").isIdentifier({ name: implementationIdentifier })) {
+  const callee = path.get("callee");
+  if (callee.isIdentifier({ name: implementationIdentifier })) {
     knownDecimalNodes.add(path.node);
+    return;
+  }
+
+  const methodName = isMathMethod(callee);
+  if (methodName && supportedMathMethods.includes(methodName)) {
+    const args = path.get("arguments");
+    if (args.every((arg) => knownDecimalNodes.has(arg.node))) {
+      knownDecimalNodes.add(path.node);
+    }
   }
 };
 
@@ -53,7 +65,9 @@ export default function (babel) {
       BinaryExpression: {
         exit: replaceWithDecimalExpression(t, knownDecimalNodes),
       },
-      CallExpression: addToDecimalNodes(t, knownDecimalNodes),
+      CallExpression: {
+        exit: addToDecimalNodes(t, knownDecimalNodes),
+      },
       DecimalLiteral: replaceWithDecimal(t, implementationIdentifier),
       UnaryExpression: {
         exit: replaceWithUnaryDecimalExpression(t, knownDecimalNodes),

--- a/transforms/dec128.js
+++ b/transforms/dec128.js
@@ -1,9 +1,11 @@
 import {
   earlyReturn,
+  isMathMethod,
   passesGeneralChecks,
   replaceWithDecimal,
   replaceWithUnaryDecimalExpression,
   sharedOpts,
+  supportedMathMethods,
 } from "./shared.js";
 
 const implementationIdentifier = "Decimal";
@@ -38,8 +40,18 @@ const replaceWithDecimalExpression = (t, knownDecimalNodes) => (path) => {
 };
 
 const addToDecimalNodes = (t, knownDecimalNodes) => (path) => {
-  if (path.get("callee").isIdentifier({ name: implementationIdentifier })) {
+  const callee = path.get("callee");
+  if (callee.isIdentifier({ name: implementationIdentifier })) {
     knownDecimalNodes.add(path.node);
+    return;
+  }
+
+  const methodName = isMathMethod(callee);
+  if (methodName && supportedMathMethods.includes(methodName)) {
+    const args = path.get("arguments");
+    if (args.every((arg) => knownDecimalNodes.has(arg.node))) {
+      knownDecimalNodes.add(path.node);
+    }
   }
 };
 
@@ -56,7 +68,9 @@ export default function (babel) {
       BinaryExpression: {
         exit: replaceWithDecimalExpression(t, knownDecimalNodes),
       },
-      CallExpression: addToDecimalNodes(t, knownDecimalNodes),
+      CallExpression: {
+        exit: addToDecimalNodes(t, knownDecimalNodes),
+      },
       DecimalLiteral: replaceWithDecimal(t, implementationIdentifier),
       UnaryExpression: {
         exit: replaceWithUnaryDecimalExpression(t, knownDecimalNodes),

--- a/transforms/shared.js
+++ b/transforms/shared.js
@@ -2,6 +2,20 @@ export const earlyReturn = (conditions) => {
   return conditions.every(Boolean);
 };
 
+export const isMathMethod = (expr) => {
+  if (!expr.isMemberExpression()) {
+    return false;
+  }
+
+  const object = expr.get("object");
+  const property = expr.get("property");
+  if (!object.isIdentifier({ name: "Math" }) || !property.isIdentifier()) {
+    return false;
+  }
+
+  return property.node.name;
+};
+
 export const passesGeneralChecks = (path, knownDecimalNodes, opToName) => {
   const includedOps = new Map(Object.entries(opToName));
 
@@ -58,3 +72,6 @@ export const sharedOpts = {
   "*": "mul",
   "-": "sub",
 };
+
+// Keep in sync with implementations in src/runner/patches.js
+export const supportedMathMethods = ["abs", "floor", "log10", "pow"];


### PR DESCRIPTION
In order to make Math functions work with Decimals, we replace them in
the preambles with versions that handle both Decimal and non-Decimal
arguments.

Most Math methods have only one argument so the override is short, but for
methods such as Math.pow() with two or more arguments we also have to
check for mixed-type arguments and throw a TypeError.

This adds tests for how the overrides behave at runtime. In order to make
the tests work, we have to add the decimal.js and big.js libraries to
package.json with the exact versions pinned that we load in
src/runner/index.html. Otherwise it's confusing, since there were other
dependencies that required earlier versions of big.js with less
functionality.