### PR TITLE
Draft: Decimal.round

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,6 +1,7 @@
 module.exports = {
   env: {
     browser: false,
+    "shared-node-browser": true,
     es2021: true,
   },
   extends: ["eslint:recommended", "prettier"],

--- a/src/app.js
+++ b/src/app.js
@@ -55,7 +55,9 @@ const useTransformedOutput = (code, decimalImpl) => {
         setTransformed(result.code);
         setTransformationError(null);
       } catch (err) {
-        setTransformationError(err);
+        setTransformationError(
+          `${err?.message ?? "Error"}\n${err?.stack ?? ""}`
+        );
       }
     };
 
@@ -155,7 +157,7 @@ const App = ({ editorModel, output, configOpts }) => {
         />
         <Output
           orderClass={orderClass(OUTPUT)}
-          content={transformationError?.message || transformedOutput}
+          content={transformationError ?? transformedOutput}
         />
         <Results
           order={{

--- a/src/constants.js
+++ b/src/constants.js
@@ -47,6 +47,8 @@ const CHECKERBOARD = "checkerboard";
 const BIG_DECIMAL = "big decimal";
 const DECIMAL_128 = "decimal 128";
 
+const PATCHED_MATH_METHODS = ["abs", "floor", "log10", "pow"];
+
 export {
   DEFAULT_TEXT,
   EDITOR_OPTIONS,
@@ -59,4 +61,5 @@ export {
   BIG_DECIMAL,
   DECIMAL_128,
   DEC_128_PREFIX,
+  PATCHED_MATH_METHODS,
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -44,7 +44,6 @@ const EDITOR = "Editor";
 const OUTPUT = "Output";
 const THREE_UP = "columns";
 const CHECKERBOARD = "checkerboard";
-// Keep in sync with src/runner/patches.js
 const BIG_DECIMAL = "big decimal";
 const DECIMAL_128 = "decimal 128";
 

--- a/src/runner/index.html
+++ b/src/runner/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
     <script src="https://unpkg.com/decimal.js@10.3.1/decimal.js"></script>
     <script src="https://unpkg.com/big.js@6.1.1/big.js"></script>
-    <script src="./patches.js"></script>
+    <script type="module" src="./patches.js"></script>
     <script src="./index.js"></script>
   </head>
 </html>

--- a/src/runner/patch-round.js
+++ b/src/runner/patch-round.js
@@ -1,0 +1,124 @@
+/* global Big, Decimal */
+
+import { BIG_DECIMAL, DECIMAL_128 } from "../constants.js";
+
+const RoundingMode = {
+  UP: "up",
+  DOWN: "down",
+  HALF_UP: "half-up",
+  HALF_DOWN: "half-down",
+  HALF_EVEN: "half-even",
+};
+
+const dec128Modes = new Map([
+  [RoundingMode.UP, Decimal.ROUND_UP],
+  [RoundingMode.DOWN, Decimal.ROUND_DOWN],
+  [RoundingMode.HALF_UP, Decimal.ROUND_HALF_UP],
+  [RoundingMode.HALF_DOWN, Decimal.ROUND_HALF_DOWN],
+  [RoundingMode.HALF_EVEN, Decimal.ROUND_HALF_EVEN],
+]);
+
+const bigDecModes = new Map([
+  [RoundingMode.UP, Big.roundUp],
+  [RoundingMode.DOWN, Big.roundDown],
+  [RoundingMode.HALF_UP, Big.roundHalfUp],
+  // half-down not present in big.js
+  [RoundingMode.HALF_EVEN, Big.roundHalfEven],
+]);
+
+const listFormatter = new Intl.ListFormat("en", { type: "disjunction" });
+const quotedModesList = listFormatter.format(
+  Object.values(RoundingMode).map((mode) => `"${mode}"`)
+);
+
+function throwUnknownRoundingMode(mode) {
+  throw new RangeError(
+    `"${mode}" isn't a recognized value for roundingMode. You need one of ${quotedModesList}`
+  );
+}
+
+const roundingModeImpl = {
+  [DECIMAL_128](mode) {
+    if (!dec128Modes.has(mode)) {
+      throwUnknownRoundingMode(mode);
+    }
+    return dec128Modes.get(mode);
+  },
+  [BIG_DECIMAL](mode) {
+    if (mode === RoundingMode.HALF_DOWN) {
+      throw new Error(
+        `"${RoundingMode.HALF_DOWN}" rounding mode not yet supported for BigDecimal. Let us know if you need this!`
+      );
+    }
+    if (!bigDecModes.has(mode)) {
+      throwUnknownRoundingMode(mode);
+    }
+    return bigDecModes.get(mode);
+  },
+};
+
+const roundFractionImpl = {
+  [DECIMAL_128](arg, fractionDigits, mode) {
+    return arg.toDecimalPlaces(fractionDigits, mode);
+  },
+  [BIG_DECIMAL](arg, fractionDigits, mode) {
+    return arg.round(fractionDigits, mode);
+  },
+};
+
+const roundSignificantImpl = {
+  [DECIMAL_128](arg, significantDigits, mode) {
+    return arg.toSignificantDigits(significantDigits, mode);
+  },
+  [BIG_DECIMAL](arg, significantDigits, mode) {
+    return arg.prec(significantDigits, mode);
+  },
+};
+
+function round(decimal, options = Object.create(null)) {
+  // decimal argument is guaranteed to be either a Decimal or Big here
+  const implName = decimal instanceof Decimal ? DECIMAL_128 : BIG_DECIMAL;
+
+  if (!options || typeof options !== "object") {
+    throw new TypeError("second argument to Decimal.round() must be an object");
+  }
+
+  let { maximumFractionDigits, maximumSignificantDigits, roundingMode } =
+    options;
+
+  if (roundingMode === undefined) {
+    throw new TypeError("roundingMode option is required for Decimal.round()");
+  }
+  const internalMode = roundingModeImpl[implName](roundingMode);
+
+  if (maximumFractionDigits !== undefined) {
+    maximumFractionDigits = +maximumFractionDigits;
+    return roundFractionImpl[implName](
+      decimal,
+      maximumFractionDigits,
+      internalMode
+    );
+  }
+
+  if (maximumSignificantDigits !== undefined) {
+    maximumSignificantDigits = +maximumSignificantDigits;
+    return roundSignificantImpl[implName](
+      decimal,
+      maximumSignificantDigits,
+      internalMode
+    );
+  }
+
+  throw new TypeError(
+    "one of maximumFractionDigits or maximumSignificantDigits options is required for Decimal.round()"
+  );
+}
+
+export const roundImpl = {
+  [DECIMAL_128](decimal, options) {
+    return round(decimal, options);
+  },
+  [BIG_DECIMAL](decimal, options) {
+    return round(decimal, options);
+  },
+};

--- a/src/runner/patch-round.js
+++ b/src/runner/patch-round.js
@@ -1,6 +1,7 @@
 /* global Big, Decimal */
 
 import { BIG_DECIMAL, DECIMAL_128 } from "../constants.js";
+import { throwUnimplemented } from "./patch-util.js";
 
 const RoundingMode = {
   UP: "up",
@@ -46,8 +47,9 @@ const roundingModeImpl = {
   },
   [BIG_DECIMAL](mode) {
     if (mode === RoundingMode.HALF_DOWN) {
-      throw new Error(
-        `"${RoundingMode.HALF_DOWN}" rounding mode not yet supported for BigDecimal. Let us know if you need this!`
+      throwUnimplemented(
+        `"${RoundingMode.HALF_DOWN}" rounding mode`,
+        "BigDecimal"
       );
     }
     if (!bigDecModes.has(mode)) {

--- a/src/runner/patch-util.js
+++ b/src/runner/patch-util.js
@@ -1,0 +1,5 @@
+export function throwUnimplemented(what, implName) {
+  throw new Error(
+    `${what} not yet supported for ${implName}. Let us know if you need this! (https://github.com/tc39/proposal-decimal)`
+  );
+}

--- a/src/runner/patches.js
+++ b/src/runner/patches.js
@@ -1,8 +1,6 @@
 /* global Big, Decimal */
 
-// Keep in sync with src/constants.js
-const BIG_DECIMAL = "big decimal";
-const DECIMAL_128 = "decimal 128";
+import { BIG_DECIMAL, DECIMAL_128 } from "../constants.js";
 
 const createUnaryHandler = (substituteFns) => ({
   apply(target, thisArg, argsList) {

--- a/src/runner/patches.js
+++ b/src/runner/patches.js
@@ -5,16 +5,17 @@ import {
   DECIMAL_128,
   PATCHED_MATH_METHODS,
 } from "../constants.js";
+import { roundImpl } from "./patch-round.js";
 
 const createUnaryHandler = (substituteFns) => ({
   apply(target, thisArg, argsList) {
     const [arg] = argsList;
     if (arg instanceof Decimal) {
-      return substituteFns[DECIMAL_128](arg);
+      return substituteFns[DECIMAL_128](...argsList);
     }
 
     if (arg instanceof Big) {
-      return substituteFns[BIG_DECIMAL](arg);
+      return substituteFns[BIG_DECIMAL](...argsList);
     }
 
     return target.apply(thisArg, argsList);
@@ -95,3 +96,7 @@ if (PATCHED_MATH_METHODS.length !== Object.keys(handlers).length) {
 PATCHED_MATH_METHODS.forEach((method) => {
   Math[method] = new Proxy(Math[method], handlers[method]);
 });
+
+Decimal.round = new Proxy(() => {
+  throw new TypeError("Decimal.round argument must be a Decimal");
+}, createUnaryHandler(roundImpl));

--- a/src/runner/patches.js
+++ b/src/runner/patches.js
@@ -6,6 +6,7 @@ import {
   PATCHED_MATH_METHODS,
 } from "../constants.js";
 import { roundImpl } from "./patch-round.js";
+import { throwUnimplemented } from "./patch-util.js";
 
 const createUnaryHandler = (substituteFns) => ({
   apply(target, thisArg, argsList) {
@@ -68,7 +69,7 @@ const floorImpl = {
 const log10Impl = {
   [DECIMAL_128]: Decimal.log10.bind(Decimal),
   [BIG_DECIMAL]() {
-    throw new Error("Math.log10() not supported for BigDecimal");
+    throwUnimplemented("Math.log10()", "BigDecimal");
   },
 };
 

--- a/test/src/runner/patches-128.test.js
+++ b/test/src/runner/patches-128.test.js
@@ -10,6 +10,115 @@ describe("Runtime tests for Decimal128", function () {
     return import("../../../src/runner/patches.js");
   });
 
+  describe("Decimal.round", function () {
+    let pi, options;
+
+    beforeAll(function () {
+      pi = Decimal("3.14159265358979");
+      options = { maximumFractionDigits: 10, roundingMode: "half-up" };
+    });
+
+    it("handles decimal", function () {
+      expect(() => Decimal.round(pi, options)).not.toThrow();
+    });
+
+    it("throws on non-decimal", function () {
+      expect(() => Decimal.round(3.14159265358979, options)).toThrow(TypeError);
+    });
+
+    it("throws on missing roundingMode", function () {
+      expect(() => Decimal.round(pi, { maximumFractionDigits: 10 })).toThrow(
+        TypeError
+      );
+    });
+
+    it("throws on missing maximumFractionDigits/maximumSignificantDigits", function () {
+      expect(() => Decimal.round(pi, { roundingMode: "half-up" })).toThrow(
+        TypeError
+      );
+    });
+
+    it("rounds to maximumFractionDigits", function () {
+      const roundingMode = "half-up";
+      expect(
+        Decimal.round(pi, { maximumFractionDigits: 4, roundingMode })
+      ).toEqual(Decimal("3.1416"));
+      expect(
+        Decimal.round(pi, { maximumFractionDigits: 6, roundingMode })
+      ).toEqual(Decimal("3.141593"));
+    });
+
+    it("rounds to maximumFractionDigits", function () {
+      const roundingMode = "half-up";
+      expect(
+        Decimal.round(pi, { maximumSignificantDigits: 4, roundingMode })
+      ).toEqual(Decimal("3.142"));
+      expect(
+        Decimal.round(pi, { maximumSignificantDigits: 6, roundingMode })
+      ).toEqual(Decimal("3.14159"));
+    });
+
+    it("up rounding mode", function () {
+      const options = { maximumFractionDigits: 0, roundingMode: "up" };
+      expect(Decimal.round(Decimal("1.1"), options)).toEqual(Decimal("2"));
+      expect(Decimal.round(Decimal("1.5"), options)).toEqual(Decimal("2"));
+      expect(Decimal.round(Decimal("1.9"), options)).toEqual(Decimal("2"));
+      expect(Decimal.round(Decimal("2.5"), options)).toEqual(Decimal("3"));
+      expect(Decimal.round(Decimal("-1.1"), options)).toEqual(Decimal("-2"));
+      expect(Decimal.round(Decimal("-1.5"), options)).toEqual(Decimal("-2"));
+      expect(Decimal.round(Decimal("-1.9"), options)).toEqual(Decimal("-2"));
+      expect(Decimal.round(Decimal("-2.5"), options)).toEqual(Decimal("-3"));
+    });
+
+    it("down rounding mode", function () {
+      const options = { maximumFractionDigits: 0, roundingMode: "down" };
+      expect(Decimal.round(Decimal("1.1"), options)).toEqual(Decimal("1"));
+      expect(Decimal.round(Decimal("1.5"), options)).toEqual(Decimal("1"));
+      expect(Decimal.round(Decimal("1.9"), options)).toEqual(Decimal("1"));
+      expect(Decimal.round(Decimal("2.5"), options)).toEqual(Decimal("2"));
+      expect(Decimal.round(Decimal("-1.1"), options)).toEqual(Decimal("-1"));
+      expect(Decimal.round(Decimal("-1.5"), options)).toEqual(Decimal("-1"));
+      expect(Decimal.round(Decimal("-1.9"), options)).toEqual(Decimal("-1"));
+      expect(Decimal.round(Decimal("-2.5"), options)).toEqual(Decimal("-2"));
+    });
+
+    it("half-up rounding mode", function () {
+      const options = { maximumFractionDigits: 0, roundingMode: "half-up" };
+      expect(Decimal.round(Decimal("1.1"), options)).toEqual(Decimal("1"));
+      expect(Decimal.round(Decimal("1.5"), options)).toEqual(Decimal("2"));
+      expect(Decimal.round(Decimal("1.9"), options)).toEqual(Decimal("2"));
+      expect(Decimal.round(Decimal("2.5"), options)).toEqual(Decimal("3"));
+      expect(Decimal.round(Decimal("-1.1"), options)).toEqual(Decimal("-1"));
+      expect(Decimal.round(Decimal("-1.5"), options)).toEqual(Decimal("-2"));
+      expect(Decimal.round(Decimal("-1.9"), options)).toEqual(Decimal("-2"));
+      expect(Decimal.round(Decimal("-2.5"), options)).toEqual(Decimal("-3"));
+    });
+
+    it("half-down rounding mode", function () {
+      const options = { maximumFractionDigits: 0, roundingMode: "half-down" };
+      expect(Decimal.round(Decimal("1.1"), options)).toEqual(Decimal("1"));
+      expect(Decimal.round(Decimal("1.5"), options)).toEqual(Decimal("1"));
+      expect(Decimal.round(Decimal("1.9"), options)).toEqual(Decimal("2"));
+      expect(Decimal.round(Decimal("2.5"), options)).toEqual(Decimal("2"));
+      expect(Decimal.round(Decimal("-1.1"), options)).toEqual(Decimal("-1"));
+      expect(Decimal.round(Decimal("-1.5"), options)).toEqual(Decimal("-1"));
+      expect(Decimal.round(Decimal("-1.9"), options)).toEqual(Decimal("-2"));
+      expect(Decimal.round(Decimal("-2.5"), options)).toEqual(Decimal("-2"));
+    });
+
+    it("half-even rounding mode", function () {
+      const options = { maximumFractionDigits: 0, roundingMode: "half-even" };
+      expect(Decimal.round(Decimal("1.1"), options)).toEqual(Decimal("1"));
+      expect(Decimal.round(Decimal("1.5"), options)).toEqual(Decimal("2"));
+      expect(Decimal.round(Decimal("1.9"), options)).toEqual(Decimal("2"));
+      expect(Decimal.round(Decimal("2.5"), options)).toEqual(Decimal("2"));
+      expect(Decimal.round(Decimal("-1.1"), options)).toEqual(Decimal("-1"));
+      expect(Decimal.round(Decimal("-1.5"), options)).toEqual(Decimal("-2"));
+      expect(Decimal.round(Decimal("-1.9"), options)).toEqual(Decimal("-2"));
+      expect(Decimal.round(Decimal("-2.5"), options)).toEqual(Decimal("-2"));
+    });
+  });
+
   describe("Math.abs", function () {
     it("handles decimal", function () {
       expect(Math.abs(Decimal("-1.5"))).toEqual(Decimal("1.5"));

--- a/test/src/runner/patches-big.test.js
+++ b/test/src/runner/patches-big.test.js
@@ -9,6 +9,115 @@ describe("Runtime tests for BigDecimal", function () {
     return import("../../../src/runner/patches.js");
   });
 
+  describe("Decimal.round", function () {
+    let pi, options;
+
+    beforeAll(function () {
+      pi = Big("3.14159265358979");
+      options = { maximumFractionDigits: 10, roundingMode: "half-up" };
+    });
+
+    it("handles decimal", function () {
+      expect(() => Decimal.round(pi, options)).not.toThrow();
+    });
+
+    it("throws on non-decimal", function () {
+      expect(() => Decimal.round(3.14159265358979, options)).toThrow(TypeError);
+    });
+
+    it("throws on missing roundingMode", function () {
+      expect(() => Decimal.round(pi, { maximumFractionDigits: 10 })).toThrow(
+        TypeError
+      );
+    });
+
+    it("throws on missing maximumFractionDigits/maximumSignificantDigits", function () {
+      expect(() => Decimal.round(pi, { roundingMode: "half-up" })).toThrow(
+        TypeError
+      );
+    });
+
+    it("rounds to maximumFractionDigits", function () {
+      const roundingMode = "half-up";
+      expect(
+        Decimal.round(pi, { maximumFractionDigits: 4, roundingMode })
+      ).toEqual(Big("3.1416"));
+      expect(
+        Decimal.round(pi, { maximumFractionDigits: 6, roundingMode })
+      ).toEqual(Big("3.141593"));
+    });
+
+    it("rounds to maximumFractionDigits", function () {
+      const roundingMode = "half-up";
+      expect(
+        Decimal.round(pi, { maximumSignificantDigits: 4, roundingMode })
+      ).toEqual(Big("3.142"));
+      expect(
+        Decimal.round(pi, { maximumSignificantDigits: 6, roundingMode })
+      ).toEqual(Big("3.14159"));
+    });
+
+    it("up rounding mode", function () {
+      const options = { maximumFractionDigits: 0, roundingMode: "up" };
+      expect(Decimal.round(Big("1.1"), options)).toEqual(Big("2"));
+      expect(Decimal.round(Big("1.5"), options)).toEqual(Big("2"));
+      expect(Decimal.round(Big("1.9"), options)).toEqual(Big("2"));
+      expect(Decimal.round(Big("2.5"), options)).toEqual(Big("3"));
+      expect(Decimal.round(Big("-1.1"), options)).toEqual(Big("-2"));
+      expect(Decimal.round(Big("-1.5"), options)).toEqual(Big("-2"));
+      expect(Decimal.round(Big("-1.9"), options)).toEqual(Big("-2"));
+      expect(Decimal.round(Big("-2.5"), options)).toEqual(Big("-3"));
+    });
+
+    it("down rounding mode", function () {
+      const options = { maximumFractionDigits: 0, roundingMode: "down" };
+      expect(Decimal.round(Big("1.1"), options)).toEqual(Big("1"));
+      expect(Decimal.round(Big("1.5"), options)).toEqual(Big("1"));
+      expect(Decimal.round(Big("1.9"), options)).toEqual(Big("1"));
+      expect(Decimal.round(Big("2.5"), options)).toEqual(Big("2"));
+      expect(Decimal.round(Big("-1.1"), options)).toEqual(Big("-1"));
+      expect(Decimal.round(Big("-1.5"), options)).toEqual(Big("-1"));
+      expect(Decimal.round(Big("-1.9"), options)).toEqual(Big("-1"));
+      expect(Decimal.round(Big("-2.5"), options)).toEqual(Big("-2"));
+    });
+
+    it("half-up rounding mode", function () {
+      const options = { maximumFractionDigits: 0, roundingMode: "half-up" };
+      expect(Decimal.round(Big("1.1"), options)).toEqual(Big("1"));
+      expect(Decimal.round(Big("1.5"), options)).toEqual(Big("2"));
+      expect(Decimal.round(Big("1.9"), options)).toEqual(Big("2"));
+      expect(Decimal.round(Big("2.5"), options)).toEqual(Big("3"));
+      expect(Decimal.round(Big("-1.1"), options)).toEqual(Big("-1"));
+      expect(Decimal.round(Big("-1.5"), options)).toEqual(Big("-2"));
+      expect(Decimal.round(Big("-1.9"), options)).toEqual(Big("-2"));
+      expect(Decimal.round(Big("-2.5"), options)).toEqual(Big("-3"));
+    });
+
+    it.skip("half-down rounding mode", function () {
+      const options = { maximumFractionDigits: 0, roundingMode: "half-down" };
+      expect(Decimal.round(Big("1.1"), options)).toEqual(Big("1"));
+      expect(Decimal.round(Big("1.5"), options)).toEqual(Big("1"));
+      expect(Decimal.round(Big("1.9"), options)).toEqual(Big("2"));
+      expect(Decimal.round(Big("2.5"), options)).toEqual(Big("2"));
+      expect(Decimal.round(Big("-1.1"), options)).toEqual(Big("-1"));
+      expect(Decimal.round(Big("-1.5"), options)).toEqual(Big("-1"));
+      expect(Decimal.round(Big("-1.9"), options)).toEqual(Big("-2"));
+      expect(Decimal.round(Big("-2.5"), options)).toEqual(Big("-2"));
+    });
+
+    it("half-even rounding mode", function () {
+      const options = { maximumFractionDigits: 0, roundingMode: "half-even" };
+      expect(Decimal.round(Big("1.1"), options)).toEqual(Big("1"));
+      expect(Decimal.round(Big("1.5"), options)).toEqual(Big("2"));
+      expect(Decimal.round(Big("1.9"), options)).toEqual(Big("2"));
+      expect(Decimal.round(Big("2.5"), options)).toEqual(Big("2"));
+      expect(Decimal.round(Big("-1.1"), options)).toEqual(Big("-1"));
+      expect(Decimal.round(Big("-1.5"), options)).toEqual(Big("-2"));
+      expect(Decimal.round(Big("-1.9"), options)).toEqual(Big("-2"));
+      expect(Decimal.round(Big("-2.5"), options)).toEqual(Big("-2"));
+    });
+  });
+
   describe("Math.abs", function () {
     it("handles decimal", function () {
       expect(Math.abs(Big("-1.5"))).toEqual(Big("1.5"));

--- a/test/transforms/bigdec.test.js
+++ b/test/transforms/bigdec.test.js
@@ -86,7 +86,18 @@ const inFunctions = {
   },
 };
 
+const longDecimalRoundOutput = `
+  Decimal.round(${libName}("1.5"), {
+    roundingMode: "up",
+    maximumFractionDigits: 0,
+  }).neg();
+`;
+
 const withKnownDecimalInputs = {
+  "works with Decimal.round": {
+    code: '-Decimal.round(1.5m, { roundingMode: "up", maximumFractionDigits: 0 });',
+    output: longDecimalRoundOutput,
+  },
   "unary Math method with known decimal input is known to be decimal": {
     code: "-Math.abs(-1.5m);",
     output: `Math.abs(${libName}("1.5").neg()).neg();`,

--- a/test/transforms/dec128.test.js
+++ b/test/transforms/dec128.test.js
@@ -90,7 +90,18 @@ const inFunctions = {
   },
 };
 
+const longDecimalRoundOutput = `
+  Decimal.round(Decimal("1.5"), {
+    roundingMode: "up",
+    maximumFractionDigits: 0,
+  }).neg();
+`;
+
 const withKnownDecimalInputs = {
+  "works with Decimal.round": {
+    code: '-Decimal.round(1.5m, { roundingMode: "up", maximumFractionDigits: 0 });',
+    output: longDecimalRoundOutput,
+  },
   "unary Math method with known decimal input is known to be decimal": {
     code: "-Math.abs(-1.5m);",
     output: 'Math.abs(Decimal("1.5").neg()).neg();',

--- a/transforms/bigdec.js
+++ b/transforms/bigdec.js
@@ -1,11 +1,10 @@
 import {
+  addToDecimalNodes,
   earlyReturn,
-  isMathMethod,
   passesGeneralChecks,
   replaceWithDecimal,
   replaceWithUnaryDecimalExpression,
   sharedOpts,
-  supportedMathMethods,
 } from "./shared.js";
 
 const implementationIdentifier = "Big";
@@ -36,22 +35,6 @@ const replaceWithDecimalExpression = (t, knownDecimalNodes) => (path) => {
   path.skip();
 };
 
-const addToDecimalNodes = (t, knownDecimalNodes) => (path) => {
-  const callee = path.get("callee");
-  if (callee.isIdentifier({ name: implementationIdentifier })) {
-    knownDecimalNodes.add(path.node);
-    return;
-  }
-
-  const methodName = isMathMethod(callee);
-  if (methodName && supportedMathMethods.includes(methodName)) {
-    const args = path.get("arguments");
-    if (args.every((arg) => knownDecimalNodes.has(arg.node))) {
-      knownDecimalNodes.add(path.node);
-    }
-  }
-};
-
 export default function (babel) {
   const { types: t } = babel;
   const knownDecimalNodes = new WeakSet();
@@ -66,7 +49,7 @@ export default function (babel) {
         exit: replaceWithDecimalExpression(t, knownDecimalNodes),
       },
       CallExpression: {
-        exit: addToDecimalNodes(t, knownDecimalNodes),
+        exit: addToDecimalNodes(t, knownDecimalNodes, implementationIdentifier),
       },
       DecimalLiteral: replaceWithDecimal(t, implementationIdentifier),
       UnaryExpression: {

--- a/transforms/shared.js
+++ b/transforms/shared.js
@@ -21,6 +21,14 @@ export const addToDecimalNodes =
             knownDecimalNodes.add(path.node);
           }
         }
+        return;
+      }
+
+      if (
+        object.isIdentifier({ name: "Decimal" }) &&
+        property.isIdentifier({ name: "round" })
+      ) {
+        knownDecimalNodes.add(path.node);
       }
     }
   };

--- a/transforms/shared.js
+++ b/transforms/shared.js
@@ -1,19 +1,32 @@
+export const addToDecimalNodes =
+  (t, knownDecimalNodes, implementationIdentifier) => (path) => {
+    const callee = path.get("callee");
+    if (callee.isIdentifier({ name: implementationIdentifier })) {
+      knownDecimalNodes.add(path.node);
+      return;
+    }
+
+    if (callee.isMemberExpression()) {
+      const object = callee.get("object");
+      const property = callee.get("property");
+
+      if (object.isIdentifier({ name: "Math" }) && property.isIdentifier()) {
+        // Keep in sync with implementations in src/runner/patches.js
+        const supportedMathMethods = ["abs", "floor", "log10", "pow"];
+        const methodName = property.node.name;
+
+        if (supportedMathMethods.includes(methodName)) {
+          const args = path.get("arguments");
+          if (args.every((arg) => knownDecimalNodes.has(arg.node))) {
+            knownDecimalNodes.add(path.node);
+          }
+        }
+      }
+    }
+  };
+
 export const earlyReturn = (conditions) => {
   return conditions.every(Boolean);
-};
-
-export const isMathMethod = (expr) => {
-  if (!expr.isMemberExpression()) {
-    return false;
-  }
-
-  const object = expr.get("object");
-  const property = expr.get("property");
-  if (!object.isIdentifier({ name: "Math" }) || !property.isIdentifier()) {
-    return false;
-  }
-
-  return property.node.name;
 };
 
 export const passesGeneralChecks = (path, knownDecimalNodes, opToName) => {
@@ -72,6 +85,3 @@ export const sharedOpts = {
   "*": "mul",
   "-": "sub",
 };
-
-// Keep in sync with implementations in src/runner/patches.js
-export const supportedMathMethods = ["abs", "floor", "log10", "pow"];

--- a/transforms/shared.js
+++ b/transforms/shared.js
@@ -1,3 +1,5 @@
+import { PATCHED_MATH_METHODS } from "../src/constants.js";
+
 export const addToDecimalNodes =
   (t, knownDecimalNodes, implementationIdentifier) => (path) => {
     const callee = path.get("callee");
@@ -11,11 +13,9 @@ export const addToDecimalNodes =
       const property = callee.get("property");
 
       if (object.isIdentifier({ name: "Math" }) && property.isIdentifier()) {
-        // Keep in sync with implementations in src/runner/patches.js
-        const supportedMathMethods = ["abs", "floor", "log10", "pow"];
         const methodName = property.node.name;
 
-        if (supportedMathMethods.includes(methodName)) {
+        if (PATCHED_MATH_METHODS.includes(methodName)) {
           const args = path.get("arguments");
           if (args.every((arg) => knownDecimalNodes.has(arg.node))) {
             knownDecimalNodes.add(path.node);


### PR DESCRIPTION
This builds on top of #11. It's got some other things in it besides Decimal.round, that I found made it easier to implement and test it:
- ~~Move the precision setting for decimal.js to the patches file - this prevents having to duplicate it in the tests. (But you mentioned in passing in my last PR that we couldn't do this, so maybe I'm missing some reason why we shouldn't. Happy to drop this commit, either way.)~~ (we won't do this so that `Decimal.set({ precision: 34 })` explicitly appears in the transformed output as shown to playground users)
- ~~Pass the implementation into a "polyfill function" so we don't have to explicitly code `Big` or `Decimal` everywhere - we don't have to do this, but I thought I'd explore it; we do have to at least rename the decimal.js global to something else besides `Decimal` or else we'll conflict with Decimal.round, and I've chosen `DecimalJS` here. (You might want to look at this commit with whitespace ignored.)~~
- Print the error stack when the transform fails, to help with debugging
- Your change from #15 to make the patching code a module
- Refactoring `addToDecimalNodes` into the shared transform code, since it is already parameterized with `implementationIdentifier`
- Move the list of patched `Math` methods into the constants file and add a consistency check to make sure they all have handlers
- A utility function to throw when we leave something temporarily unimplemented

Feel free to drop any of the refactors if you don't like them.