### PR TITLE
Add Decimal constructor

### DIFF
--- a/.github/workflows/main-to-website.yml
+++ b/.github/workflows/main-to-website.yml
@@ -2,7 +2,7 @@ name: Build and Push Main to Website
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
     types:
       - closed
 
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: "14"
       - run: |
           echo The PR was merged
       - run: npm install

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 **/node_modules
 **/.DS_Store
-*/dist
+**/dist

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ There is a [list of features to be implemented](https://sarahghp.notion.site/083
 
 To run the project locally, run `npm run dev` in a terminal window.
 
-
 ### Tests
 
 All new capabilities added to the `/transforms` directory must have corresponding tests. These are written using [babel-plugin-tester](https://github.com/babel-utils/babel-plugin-tester).

--- a/src/constants.js
+++ b/src/constants.js
@@ -24,7 +24,7 @@ document.querySelector('body').append(b);
 
 const DEC_128_PREFIX = `
   // Decimal128 allows for 34 digits of significand
-  Decimal.set({precision: 34});
+  Decimal128.set({precision: 34});
 `;
 
 const EDITOR_OPTIONS = {
@@ -48,6 +48,7 @@ const BIG_DECIMAL = "big decimal";
 const DECIMAL_128 = "decimal 128";
 
 const PATCHED_MATH_METHODS = ["abs", "floor", "log10", "pow"];
+const PATCHED_DECIMAL_METHODS = ["round"];
 
 export {
   DEFAULT_TEXT,
@@ -62,4 +63,5 @@ export {
   DECIMAL_128,
   DEC_128_PREFIX,
   PATCHED_MATH_METHODS,
+  PATCHED_DECIMAL_METHODS,
 };

--- a/src/runner/index.html
+++ b/src/runner/index.html
@@ -5,6 +5,9 @@
     <meta charset="utf-8" />
     <script src="https://unpkg.com/decimal.js@10.3.1/decimal.js"></script>
     <script src="https://unpkg.com/big.js@6.1.1/big.js"></script>
+    <script>
+      const Decimal128 = Decimal.clone();
+    </script>
     <script type="module" src="./patches.js"></script>
     <script src="./index.js"></script>
   </head>

--- a/src/runner/patch-math.js
+++ b/src/runner/patch-math.js
@@ -51,6 +51,4 @@ const checkAndInitMathHandlers = (createUnaryHandler, createNaryHandler) => {
   });
 };
 
-export {
-  checkAndInitMathHandlers
-}
+export { checkAndInitMathHandlers };

--- a/src/runner/patch-util.js
+++ b/src/runner/patch-util.js
@@ -59,5 +59,5 @@ export {
   createUnaryHandler,
   createNaryHandler,
   decimalOnlyBaseFn,
-  throwUnimplemented
+  throwUnimplemented,
 };

--- a/src/runner/patches.js
+++ b/src/runner/patches.js
@@ -1,16 +1,13 @@
 /* global Big, Decimal */
 
-import {
-  BIG_DECIMAL,
-  DECIMAL_128,
-} from "../constants.js";
-import { checkAndInitMathHandlers } from './patch-math.js'
+import { BIG_DECIMAL, DECIMAL_128 } from "../constants.js";
+import { checkAndInitMathHandlers } from "./patch-math.js";
 import { roundImpl } from "./patch-round.js";
 import {
   createUnaryHandler,
   createNaryHandler,
   decimalOnlyBaseFn,
-  throwUnimplemented
+  throwUnimplemented,
 } from "./patch-util.js";
 
 checkAndInitMathHandlers(createUnaryHandler, createNaryHandler);

--- a/test/transforms/bigdec.test.js
+++ b/test/transforms/bigdec.test.js
@@ -21,49 +21,57 @@ const basic = {
 const constructor = {
   "works with plain number": {
     code: "Decimal(1);",
-    output: `${libName}(1);`
+    output: `${libName}(1);`,
   },
   "works with string": {
     code: 'Decimal("1");',
-    output: `${libName}("1");`
+    output: `${libName}("1");`,
   },
   "passes expression through": {
-    code: 'Decimal(1 + 1);',
-    output: `${libName}(1 + 1);`
+    code: "Decimal(1 + 1);",
+    output: `${libName}(1 + 1);`,
   },
   "throws on null": {
     code: "Decimal(null)",
-    error: "TypeError: Can't convert null or undefined to Decimal."
+    error: "TypeError: Can't convert null or undefined to Decimal.",
   },
   "throws on explicit undefined": {
     code: "Decimal(undefined)",
-    error: "TypeError: Can't convert null or undefined to Decimal."
+    error: "TypeError: Can't convert null or undefined to Decimal.",
   },
   "throws on implicit undefined": {
     code: "Decimal()",
-    error: "TypeError: Can't convert null or undefined to Decimal."
+    error: "TypeError: Can't convert null or undefined to Decimal.",
   },
   "coerces boolean true": {
     code: "Decimal(true);",
-    output: `${libName}(1);`
+    output: `${libName}(1);`,
   },
   "coerces boolean false": {
     code: "Decimal(false);",
-    output: `${libName}(0);`
+    output: `${libName}(0);`,
   },
   "coerces BigInt": {
     code: "Decimal(1n);",
-    output: `${libName}("1");`
+    output: `${libName}("1");`,
   },
-  "does not affect Decimal MemberExpressions":{
+  "works with Decimal literal": {
+    code: "Decimal(1.5m);",
+    output: `${libName}(${libName}("1.5"));`,
+  },
+  "works with nested Decimal call": {
+    code: "Decimal(Decimal(1));",
+    output: `${libName}(${libName}(1));`,
+  },
+  "does not affect Decimal MemberExpressions": {
     code: "Decimal.round(24.5m, { roundingMode: 'half-up', maximumFractionDigits: 0, })",
     output: `
     Decimal.round(${libName}("24.5"), {
       roundingMode: "half-up",
       maximumFractionDigits: 0,
-    });`
-  }
-}
+    });`,
+  },
+};
 
 const doesNotChangeNumbers = {
   "does not change Numbers": "111.4 + 12 - 22;",

--- a/test/transforms/bigdec.test.js
+++ b/test/transforms/bigdec.test.js
@@ -18,6 +18,53 @@ const basic = {
   },
 };
 
+const constructor = {
+  "works with plain number": {
+    code: "Decimal(1);",
+    output: `${libName}(1);`
+  },
+  "works with string": {
+    code: 'Decimal("1");',
+    output: `${libName}("1");`
+  },
+  "passes expression through": {
+    code: 'Decimal(1 + 1);',
+    output: `${libName}(1 + 1);`
+  },
+  "throws on null": {
+    code: "Decimal(null)",
+    error: "TypeError: Can't convert null or undefined to Decimal."
+  },
+  "throws on explicit undefined": {
+    code: "Decimal(undefined)",
+    error: "TypeError: Can't convert null or undefined to Decimal."
+  },
+  "throws on implicit undefined": {
+    code: "Decimal()",
+    error: "TypeError: Can't convert null or undefined to Decimal."
+  },
+  "coerces boolean true": {
+    code: "Decimal(true);",
+    output: `${libName}(1);`
+  },
+  "coerces boolean false": {
+    code: "Decimal(false);",
+    output: `${libName}(0);`
+  },
+  "coerces BigInt": {
+    code: "Decimal(1n);",
+    output: `${libName}("1");`
+  },
+  "does not affect Decimal MemberExpressions":{
+    code: "Decimal.round(24.5m, { roundingMode: 'half-up', maximumFractionDigits: 0, })",
+    output: `
+    Decimal.round(${libName}("24.5"), {
+      roundingMode: "half-up",
+      maximumFractionDigits: 0,
+    });`
+  }
+}
+
 const doesNotChangeNumbers = {
   "does not change Numbers": "111.4 + 12 - 22;",
   "does not change Numbers in nested BinaryExpressions":
@@ -43,9 +90,7 @@ const operators = {
   },
 };
 
-const nestedOutput = `
-  ${libName}("0.4").add(${libName}("11.3").sub(${libName}("89").mul(${libName}("10").add(${libName}("33.45")))));
-`;
+const nestedOutput = `${libName}("0.4").add(${libName}("11.3").sub(${libName}("89").mul(${libName}("10").add(${libName}("33.45")))));`;
 
 const longNestedOutput = `
   ${libName}("21.3")
@@ -125,6 +170,7 @@ pluginTester({
   pluginName: "plugin-big-decimal",
   tests: {
     ...basic,
+    ...constructor,
     ...operators,
     ...inBinaryExpressions,
     ...inFunctions,

--- a/test/transforms/dec128.test.js
+++ b/test/transforms/dec128.test.js
@@ -1,18 +1,20 @@
 import pluginTester from "babel-plugin-tester";
 import pluginDec128 from "../../transforms/dec128.js";
 
+const libName = "Decimal128";
+
 const basic = {
   "transforms literal": {
     code: "1000.2m",
-    output: 'Decimal("1000.2");',
+    output: `${libName}("1000.2");`,
   },
   "transforms literal without point": {
     code: "1000m",
-    output: 'Decimal("1000");',
+    output: `${libName}("1000");`,
   },
   "transforms literal with point at end": {
     code: "1000.m",
-    output: 'Decimal("1000.");',
+    output: `${libName}("1000.");`,
   },
 };
 
@@ -22,52 +24,101 @@ const doesNotChangeNumbers = {
     "(1 + (4 - 2)) * (3 + 4);",
 };
 
+const constructor = {
+  "works with plain number": {
+    code: "Decimal(1);",
+    output: `${libName}(1);`
+  },
+  "works with string": {
+    code: 'Decimal("1");',
+    output: `${libName}("1");`
+  },
+  "passes expression through": {
+    code: 'Decimal(1 + 1);',
+    output: `${libName}(1 + 1);`
+  },
+  "throws on null": {
+    code: "Decimal(null)",
+    error: "TypeError: Can't convert null or undefined to Decimal."
+  },
+  "throws on explicit undefined": {
+    code: "Decimal(undefined)",
+    error: "TypeError: Can't convert null or undefined to Decimal."
+  },
+  "throws on implicit undefined": {
+    code: "Decimal()",
+    error: "TypeError: Can't convert null or undefined to Decimal."
+  },
+  "coerces boolean true": {
+    code: "Decimal(true);",
+    output: `${libName}(1);`
+  },
+  "coerces boolean false": {
+    code: "Decimal(false);",
+    output: `${libName}(0);`
+  },
+  "coerces BigInt": {
+    code: "Decimal(1n);",
+    output: `${libName}("1");`
+  },
+  "does not affect Decimal MemberExpressions":{
+    code: "Decimal.round(24.5m, { roundingMode: 'half-up', maximumFractionDigits: 0, })",
+    output: `
+    Decimal.round(${libName}("24.5"), {
+      roundingMode: "half-up",
+      maximumFractionDigits: 0,
+    });`
+  }
+};
+
 const operators = {
   "converts + to .add()": {
     code: "10.3m + 12.4m",
-    output: 'Decimal("10.3").add(Decimal("12.4"));',
+    output: `${libName}("10.3").add(${libName}("12.4"));`,
   },
   "converts - to .sub()": {
     code: "10.3m - 12.4m",
-    output: 'Decimal("10.3").sub(Decimal("12.4"));',
+    output: `${libName}("10.3").sub(${libName}("12.4"));`,
   },
   "converts * to .mult()": {
     code: "10.3m * 12.4m",
-    output: 'Decimal("10.3").mul(Decimal("12.4"));',
+    output: `${libName}("10.3").mul(${libName}("12.4"));`,
   },
   "converts / to .div()": {
     code: "10.3m / 12.4m",
-    output: 'Decimal("10.3").div(Decimal("12.4"));',
+    output: `${libName}("10.3").div(${libName}("12.4"));`,
   },
   "converts unary - to .neg()": {
     code: "-10.3m + -12.4m",
-    output: 'Decimal("10.3").neg().add(Decimal("12.4").neg());',
+    output: `${libName}("10.3").neg().add(${libName}("12.4").neg());`,
   },
 };
 
 const nestedOutput = `
-  Decimal("0.4").add(
-    Decimal("11.3").sub(Decimal("89").mul(Decimal("10").div(Decimal("33.45"))))
+  ${libName}("0.4").add(
+    ${libName}("11.3").sub(
+      ${libName}("89").mul(${libName}("10").div(${libName}("33.45")))
+    )
   );
 `;
 
 const longNestedOutput = `
-  Decimal(\"21.3\")
-    .mul(Decimal("0.4").add(Decimal("11.3")))
-    .sub(Decimal("10").mul(Decimal("10000.").add(Decimal("90"))))
-    .sub(Decimal("80"))
-    .add(Decimal("35.67").mul(Decimal("103429.642950")))
-    .add(Decimal("21.3").mul(Decimal("0.4").add(Decimal("11.3"))))
-    .sub(Decimal("10").mul(Decimal("10000.")))
-    .add(Decimal("90"))
-    .sub(Decimal("80"))
-    .add(Decimal("35.67").mul(Decimal("103429.642950")));
+  ${libName}(\"21.3\")
+    .mul(${libName}("0.4").add(${libName}("11.3")))
+    .sub(${libName}("10").mul(${libName}("10000.").add(${libName}("90"))))
+    .sub(${libName}("80"))
+    .add(${libName}("35.67").mul(${libName}("103429.642950")))
+    .add(${libName}("21.3").mul(${libName}("0.4").add(${libName}("11.3"))))
+    .sub(${libName}("10").mul(${libName}("10000.")))
+    .add(${libName}("90"))
+    .sub(${libName}("80"))
+    .add(${libName}("35.67").mul(${libName}("103429.642950")));
 `;
 
 const inBinaryExpressions = {
   "transforms nested BinaryExpressions without parens": {
     code: "0.4m + 11.3m + 89m;",
-    output: 'Decimal("0.4").add(Decimal("11.3")).add(Decimal("89"));',
+    output: `${libName}("0.4").add(${libName}("11.3")).add(${libName}("89"));`,
   },
   "transforms nested BinaryExpressions with parens": {
     code: "0.4m + (11.3m - 89m * (10m / 33.45m));",
@@ -79,7 +130,7 @@ const inBinaryExpressions = {
   },
   "transforms negation of expression": {
     code: "-(0.001m + 17.6m)",
-    output: 'Decimal("0.001").add(Decimal("17.6")).neg();',
+    output: `${libName}("0.001").add(${libName}("17.6")).neg();`,
   },
 };
 
@@ -91,7 +142,7 @@ const inFunctions = {
 };
 
 const longDecimalRoundOutput = `
-  Decimal.round(Decimal("1.5"), {
+  Decimal.round(${libName}("1.5"), {
     roundingMode: "up",
     maximumFractionDigits: 0,
   }).neg();
@@ -104,7 +155,7 @@ const withKnownDecimalInputs = {
   },
   "unary Math method with known decimal input is known to be decimal": {
     code: "-Math.abs(-1.5m);",
-    output: 'Math.abs(Decimal("1.5").neg()).neg();',
+    output: `Math.abs(${libName}("1.5").neg()).neg();`,
   },
   "unary Math method with known non-decimal input is not transformed": {
     code: "-Math.abs(-1.5);",
@@ -112,7 +163,7 @@ const withKnownDecimalInputs = {
   },
   "n-ary Math method with known decimal inputs is known to be decimal": {
     code: "-Math.pow(1.01m, 12m);",
-    output: 'Math.pow(Decimal("1.01"), Decimal("12")).neg();',
+    output: `Math.pow(${libName}("1.01"), ${libName}("12")).neg();`,
   },
   "n-ary Math method with known non-decimal inputs is not transformed": {
     code: "-Math.pow(1.01, 12);",
@@ -120,7 +171,7 @@ const withKnownDecimalInputs = {
   },
   "n-ary math method with mixed inputs is not transformed": {
     code: "-Math.pow(1.01m, 12);",
-    output: '-Math.pow(Decimal("1.01"), 12);',
+    output: `-Math.pow(${libName}("1.01"), 12);`,
   },
 };
 
@@ -129,6 +180,7 @@ pluginTester({
   pluginName: "plugin-decimal-128",
   tests: {
     ...basic,
+    ...constructor,
     ...operators,
     ...inBinaryExpressions,
     ...inFunctions,

--- a/test/transforms/dec128.test.js
+++ b/test/transforms/dec128.test.js
@@ -27,48 +27,56 @@ const doesNotChangeNumbers = {
 const constructor = {
   "works with plain number": {
     code: "Decimal(1);",
-    output: `${libName}(1);`
+    output: `${libName}(1);`,
   },
   "works with string": {
     code: 'Decimal("1");',
-    output: `${libName}("1");`
+    output: `${libName}("1");`,
   },
   "passes expression through": {
-    code: 'Decimal(1 + 1);',
-    output: `${libName}(1 + 1);`
+    code: "Decimal(1 + 1);",
+    output: `${libName}(1 + 1);`,
   },
   "throws on null": {
     code: "Decimal(null)",
-    error: "TypeError: Can't convert null or undefined to Decimal."
+    error: "TypeError: Can't convert null or undefined to Decimal.",
   },
   "throws on explicit undefined": {
     code: "Decimal(undefined)",
-    error: "TypeError: Can't convert null or undefined to Decimal."
+    error: "TypeError: Can't convert null or undefined to Decimal.",
   },
   "throws on implicit undefined": {
     code: "Decimal()",
-    error: "TypeError: Can't convert null or undefined to Decimal."
+    error: "TypeError: Can't convert null or undefined to Decimal.",
   },
   "coerces boolean true": {
     code: "Decimal(true);",
-    output: `${libName}(1);`
+    output: `${libName}(1);`,
   },
   "coerces boolean false": {
     code: "Decimal(false);",
-    output: `${libName}(0);`
+    output: `${libName}(0);`,
   },
   "coerces BigInt": {
     code: "Decimal(1n);",
-    output: `${libName}("1");`
+    output: `${libName}("1");`,
   },
-  "does not affect Decimal MemberExpressions":{
+  "works with Decimal literal": {
+    code: "Decimal(1.5m);",
+    output: `${libName}(${libName}("1.5"));`,
+  },
+  "works with nested Decimal call": {
+    code: "Decimal(Decimal(1));",
+    output: `${libName}(${libName}(1));`,
+  },
+  "does not affect Decimal MemberExpressions": {
     code: "Decimal.round(24.5m, { roundingMode: 'half-up', maximumFractionDigits: 0, })",
     output: `
     Decimal.round(${libName}("24.5"), {
       roundingMode: "half-up",
       maximumFractionDigits: 0,
-    });`
-  }
+    });`,
+  },
 };
 
 const operators = {

--- a/transforms/bigdec.js
+++ b/transforms/bigdec.js
@@ -1,6 +1,6 @@
 import {
-  addToDecimalNodes,
   earlyReturn,
+  handleCallExpression,
   passesGeneralChecks,
   replaceWithDecimal,
   replaceWithUnaryDecimalExpression,
@@ -49,7 +49,11 @@ export default function (babel) {
         exit: replaceWithDecimalExpression(t, knownDecimalNodes),
       },
       CallExpression: {
-        exit: addToDecimalNodes(t, knownDecimalNodes, implementationIdentifier),
+        exit: handleCallExpression(
+          t,
+          knownDecimalNodes,
+          implementationIdentifier
+        ),
       },
       DecimalLiteral: replaceWithDecimal(t, implementationIdentifier),
       UnaryExpression: {

--- a/transforms/dec128.js
+++ b/transforms/dec128.js
@@ -1,13 +1,13 @@
 import {
-  addToDecimalNodes,
   earlyReturn,
+  handleCallExpression,
   passesGeneralChecks,
   replaceWithDecimal,
   replaceWithUnaryDecimalExpression,
   sharedOpts,
 } from "./shared.js";
 
-const implementationIdentifier = "Decimal";
+const implementationIdentifier = "Decimal128";
 
 const opToName = {
   ...sharedOpts,
@@ -52,7 +52,11 @@ export default function (babel) {
         exit: replaceWithDecimalExpression(t, knownDecimalNodes),
       },
       CallExpression: {
-        exit: addToDecimalNodes(t, knownDecimalNodes, implementationIdentifier),
+        exit: handleCallExpression(
+          t,
+          knownDecimalNodes,
+          implementationIdentifier
+        ),
       },
       DecimalLiteral: replaceWithDecimal(t, implementationIdentifier),
       UnaryExpression: {

--- a/transforms/shared.js
+++ b/transforms/shared.js
@@ -1,35 +1,100 @@
-import { PATCHED_MATH_METHODS } from "../src/constants.js";
+import {
+  PATCHED_MATH_METHODS,
+  PATCHED_DECIMAL_METHODS,
+} from "../src/constants.js";
 
-export const addToDecimalNodes =
+const builtInLibraryName = "Decimal";
+
+const coerceConstructorArg = (path, t) => {
+  const args = path.get("arguments");
+  const [first] = args;
+
+  if (
+    !args.length ||
+    first.isNullLiteral() ||
+    first.isIdentifier({ name: "undefined" })
+  ) {
+    throw path.buildCodeFrameError(
+      new TypeError(`Can't convert null or undefined to Decimal.`)
+    );
+  }
+
+  if (first.isBooleanLiteral()) {
+    return t.NumericLiteral(Number(first.node.value));
+  }
+
+  if (first.isBigIntLiteral()) {
+    return t.StringLiteral(first.node.value);
+  }
+
+  return first.node;
+};
+
+const handleIdentifierCall = (
+  path,
+  implementationIdentifier,
+  knownDecimalNodes,
+  t
+) => {
+  if (path.get("callee").isIdentifier({ name: implementationIdentifier })) {
+    knownDecimalNodes.add(path.node);
+    return;
+  }
+
+  if (path.get("callee").isIdentifier({ name: builtInLibraryName })) {
+    const val = coerceConstructorArg(path, t);
+    const newNode = t.callExpression(t.Identifier(implementationIdentifier), [
+      val,
+    ]);
+
+    knownDecimalNodes.add(newNode);
+    path.replaceWith(newNode);
+    path.skip();
+    return;
+  }
+};
+
+const handleMemberCall = (path, knownDecimalNodes) => {
+  const callee = path.get("callee");
+  const object = callee.get("object");
+  const property = callee.get("property");
+  const methodName = property.isIdentifier()
+    ? property.node.name
+    : property.node.value;
+
+  if (
+    object.isIdentifier({ name: "Math" }) &&
+    PATCHED_MATH_METHODS.includes(methodName)
+  ) {
+    knownDecimalNodes.add(path.node);
+    return;
+  }
+
+  if (
+    object.isIdentifier({ name: builtInLibraryName }) &&
+    PATCHED_DECIMAL_METHODS.includes(methodName)
+  ) {
+    knownDecimalNodes.add(path.node);
+  }
+};
+
+export const handleCallExpression =
   (t, knownDecimalNodes, implementationIdentifier) => (path) => {
     const callee = path.get("callee");
-    if (callee.isIdentifier({ name: implementationIdentifier })) {
-      knownDecimalNodes.add(path.node);
+
+    if (callee.isIdentifier()) {
+      handleIdentifierCall(
+        path,
+        implementationIdentifier,
+        knownDecimalNodes,
+        t
+      );
       return;
     }
 
     if (callee.isMemberExpression()) {
-      const object = callee.get("object");
-      const property = callee.get("property");
-
-      if (object.isIdentifier({ name: "Math" }) && property.isIdentifier()) {
-        const methodName = property.node.name;
-
-        if (PATCHED_MATH_METHODS.includes(methodName)) {
-          const args = path.get("arguments");
-          if (args.every((arg) => knownDecimalNodes.has(arg.node))) {
-            knownDecimalNodes.add(path.node);
-          }
-        }
-        return;
-      }
-
-      if (
-        object.isIdentifier({ name: "Decimal" }) &&
-        property.isIdentifier({ name: "round" })
-      ) {
-        knownDecimalNodes.add(path.node);
-      }
+      handleMemberCall(path, knownDecimalNodes);
+      return;
     }
   };
 


### PR DESCRIPTION
This adds the `Decimal` constructor behavior to the transforms. As we discussed, this specific behavior is implemented in the transform, since we can't switch on the arguments, as we can for everything else that goes through the proxies. The contained code:

* Aliases the internal instance of `decimal.js` to `Decimal128` so that the generated code distinguishes between cases where we are using the library and cases where we are referring to the proposed `Decimal` type

* Coerces `Boolean` and `BigInt` arguments to the constructor; throws on `null` and `undefined` arguments; and passes other expressions through. It does not however check for incorrect argument types (array, object, etc.), so these will throw a library error. I think this is the correct line to draw for an experimental playground.

* Refactors the `CallExpression` handler to get rid of nested ifs and break cases out into smaller functions.

* Adds tests.