### PR TITLE
Fix unary - for BigDecimal

### DIFF
--- a/test/transforms/bigdec.test.js
+++ b/test/transforms/bigdec.test.js
@@ -33,13 +33,13 @@ const operators = {
     code: "10.3m - 12.4m",
     output: `${libName}("10.3").sub(${libName}("12.4"));`,
   },
-  "converts * to .mult()": {
+  "converts * to .mul()": {
     code: "10.3m * 12.4m",
     output: `${libName}("10.3").mul(${libName}("12.4"));`,
   },
-  "converts unary - to .neg()": {
+  "converts unary - to .mul(-1)": {
     code: "-10.3m + -12.4m",
-    output: `${libName}("10.3").neg().add(${libName}("12.4").neg());`,
+    output: `${libName}("10.3").mul(-1).add(${libName}("12.4").mul(-1));`,
   },
 };
 
@@ -75,7 +75,7 @@ const inBinaryExpressions = {
   },
   "transforms negation of expression": {
     code: "-(0.001m + 17.6m)",
-    output: `${libName}("0.001").add(${libName}("17.6")).neg();`,
+    output: `${libName}("0.001").add(${libName}("17.6")).mul(-1);`,
   },
 };
 
@@ -90,7 +90,7 @@ const longDecimalRoundOutput = `
   Decimal.round(${libName}("1.5"), {
     roundingMode: "up",
     maximumFractionDigits: 0,
-  }).neg();
+  }).mul(-1);
 `;
 
 const withKnownDecimalInputs = {
@@ -100,7 +100,7 @@ const withKnownDecimalInputs = {
   },
   "unary Math method with known decimal input is known to be decimal": {
     code: "-Math.abs(-1.5m);",
-    output: `Math.abs(${libName}("1.5").neg()).neg();`,
+    output: `Math.abs(${libName}("1.5").mul(-1)).mul(-1);`,
   },
   "unary Math method with known non-decimal input is not transformed": {
     code: "-Math.abs(-1.5);",
@@ -108,7 +108,7 @@ const withKnownDecimalInputs = {
   },
   "n-ary Math method with known decimal inputs is known to be decimal": {
     code: "-Math.pow(1.01m, 12m);",
-    output: `Math.pow(${libName}("1.01"), ${libName}("12")).neg();`,
+    output: `Math.pow(${libName}("1.01"), ${libName}("12")).mul(-1);`,
   },
   "n-ary Math method with known non-decimal inputs is not transformed": {
     code: "-Math.pow(1.01, 12);",

--- a/transforms/bigdec.js
+++ b/transforms/bigdec.js
@@ -3,7 +3,6 @@ import {
   earlyReturn,
   passesGeneralChecks,
   replaceWithDecimal,
-  replaceWithUnaryDecimalExpression,
   sharedOpts,
 } from "./shared.js";
 
@@ -28,6 +27,30 @@ const replaceWithDecimalExpression = (t, knownDecimalNodes) => (path) => {
   const member = t.memberExpression(left, t.identifier(opToName[operator]));
 
   const newNode = t.callExpression(member, [right]);
+
+  knownDecimalNodes.add(newNode);
+
+  path.replaceWith(newNode);
+  path.skip();
+};
+
+const replaceWithUnaryDecimalExpression = (t, knownDecimalNodes) => (path) => {
+  const { argument, operator } = path.node;
+
+  if (!knownDecimalNodes.has(argument)) {
+    return;
+  }
+
+  if (operator !== "-") {
+    throw path.buildCodeFrameError(
+      new SyntaxError(`Unary ${operator} is not currently supported.`)
+    );
+  }
+
+  /* Add function(s) for implementation-specific checks here */
+
+  const member = t.memberExpression(argument, t.identifier("mul"));
+  const newNode = t.callExpression(member, [t.numericLiteral(-1)]);
 
   knownDecimalNodes.add(newNode);
 

--- a/transforms/dec128.js
+++ b/transforms/dec128.js
@@ -3,7 +3,6 @@ import {
   earlyReturn,
   passesGeneralChecks,
   replaceWithDecimal,
-  replaceWithUnaryDecimalExpression,
   sharedOpts,
 } from "./shared.js";
 
@@ -31,6 +30,30 @@ const replaceWithDecimalExpression = (t, knownDecimalNodes) => (path) => {
   const member = t.memberExpression(left, t.identifier(opToName[operator]));
 
   const newNode = t.callExpression(member, [right]);
+
+  knownDecimalNodes.add(newNode);
+
+  path.replaceWith(newNode);
+  path.skip();
+};
+
+const replaceWithUnaryDecimalExpression = (t, knownDecimalNodes) => (path) => {
+  const { argument, operator } = path.node;
+
+  if (!knownDecimalNodes.has(argument)) {
+    return;
+  }
+
+  if (operator !== "-") {
+    throw path.buildCodeFrameError(
+      new SyntaxError(`Unary ${operator} is not currently supported.`)
+    );
+  }
+
+  /* Add function(s) for implementation-specific checks here */
+
+  const member = t.memberExpression(argument, t.identifier("neg"));
+  const newNode = t.callExpression(member, []);
 
   knownDecimalNodes.add(newNode);
 

--- a/transforms/shared.js
+++ b/transforms/shared.js
@@ -65,29 +65,6 @@ export const replaceWithDecimal = (t, implementationIdentifier) => (path) => {
   path.replaceWith(t.callExpression(callee, [num]));
 };
 
-export const replaceWithUnaryDecimalExpression =
-  (t, knownDecimalNodes) => (path) => {
-    const { argument, operator } = path.node;
-
-    if (!knownDecimalNodes.has(argument)) {
-      return;
-    }
-
-    if (operator !== "-") {
-      throw path.buildCodeFrameError(
-        new SyntaxError(`${operator} is not currently supported.`)
-      );
-    }
-
-    const member = t.memberExpression(argument, t.identifier("neg"));
-    const newNode = t.callExpression(member, []);
-
-    knownDecimalNodes.add(newNode);
-
-    path.replaceWith(newNode);
-    path.skip();
-  };
-
 export const sharedOpts = {
   "+": "add",
   "*": "mul",


### PR DESCRIPTION
The .neg() method doesn't actually exist on big.js instances. To negate a
big.js instance, we have to use .mul(-1).

This removes replaceWithUnaryDecimalExpression out of the shared transform
code and into the specific transforms, since we can no longer perform the
same transformation for Decimal128 and BigDecimal, or easily express the
differences in a table of method names like we do with `sharedOpts` for
the binary expressions.

Closes: #26