### PR TITLE
Handle variable madness

### DIFF
--- a/src/runner/globals.js
+++ b/src/runner/globals.js
@@ -1,0 +1,14 @@
+/*
+  This is a file for things we need to declare in the global scope.
+  Use only under the greatest duress.
+*/
+
+const Decimal128 = Decimal.clone();
+
+const wrappedBinaryIdentifier = (a) => {
+  if (!(a instanceof Decimal128 || a instanceof Big)) {
+    throw new SyntaxError("Mixed numeric types are not allowed.")
+  }
+
+  return a;
+};

--- a/src/runner/globals.js
+++ b/src/runner/globals.js
@@ -12,3 +12,19 @@ const wrappedBinaryIdentifier = (a) => {
 
   return a;
 };
+
+const wrappedConstructorIdentifier = (a) => {
+  if (a === null || a === undefined) {
+    throw new TypeError(`Can't convert null or undefined to Decimal.`);
+  }
+
+  if (typeof a === "boolean") {
+    return Number(a);
+  }
+
+  if (typeof a === "bigint") {
+    return String(a);
+  }
+
+  return a;
+}

--- a/src/runner/index.html
+++ b/src/runner/index.html
@@ -5,9 +5,7 @@
     <meta charset="utf-8" />
     <script src="https://unpkg.com/decimal.js@10.3.1/decimal.js"></script>
     <script src="https://unpkg.com/big.js@6.1.1/big.js"></script>
-    <script>
-      const Decimal128 = Decimal.clone();
-    </script>
+    <script src="./globals.js"</script>
     <script type="module" src="./patches.js"></script>
     <script src="./index.js"></script>
   </head>

--- a/src/runner/patch-util.js
+++ b/src/runner/patch-util.js
@@ -3,7 +3,7 @@ import { BIG_DECIMAL, DECIMAL_128 } from "../constants.js";
 const createUnaryHandler = (substituteFns) => ({
   apply(target, thisArg, argsList) {
     const [arg] = argsList;
-    if (arg instanceof Decimal) {
+    if (arg instanceof Decimal128) {
       return substituteFns[DECIMAL_128](...argsList);
     }
 
@@ -35,7 +35,7 @@ const createNaryHandler = (substituteFns, refiner = () => true) => ({
 
     // We assume that the args are not mixed decimal versions
     // because if they are other things have gone very badly
-    if (argsList[0] instanceof Decimal) {
+    if (argsList[0] instanceof Decimal128) {
       return substituteFns[DECIMAL_128](...argsList);
     }
 

--- a/transforms/bigdec.js
+++ b/transforms/bigdec.js
@@ -11,10 +11,19 @@ const implementationIdentifier = "Big";
 const opToName = sharedOpts;
 
 const replaceWithDecimalExpression = (t, knownDecimalNodes) => (path) => {
-  const { left, right, operator } = path.node;
+  let { left, right, operator } = path.node;
 
-  const leftIsDecimal = knownDecimalNodes.has(left);
-  const rightIsDecimal = knownDecimalNodes.has(right);
+  if (path.get("left").isIdentifier()) {
+    left = t.callExpression(t.identifier('wrappedBinaryIdentifier'), [left])
+  }
+
+  if (path.get("right").isIdentifier()) {
+    right = t.callExpression(t.identifier('wrappedBinaryIdentifier'), [right])
+  }
+
+  const argumentIsIdentifier = path.get("left").isIdentifier() || path.get("right").isIdentifier();
+  const leftIsDecimal = knownDecimalNodes.has(left) || argumentIsIdentifier;
+  const rightIsDecimal = knownDecimalNodes.has(right) || argumentIsIdentifier;
 
   if (earlyReturn([!leftIsDecimal && !rightIsDecimal])) {
     return;

--- a/transforms/dec128.js
+++ b/transforms/dec128.js
@@ -14,10 +14,20 @@ const opToName = {
 };
 
 const replaceWithDecimalExpression = (t, knownDecimalNodes) => (path) => {
-  const { left, right, operator } = path.node;
 
-  const leftIsDecimal = knownDecimalNodes.has(left);
-  const rightIsDecimal = knownDecimalNodes.has(right);
+  let { left, right, operator } = path.node;
+
+  if (path.get("left").isIdentifier()) {
+    left = t.callExpression(t.identifier('wrappedBinaryIdentifier'), [left])
+  }
+
+  if (path.get("right").isIdentifier()) {
+    right = t.callExpression(t.identifier('wrappedBinaryIdentifier'), [right])
+  }
+
+  const argumentIsIdentifier = path.get("left").isIdentifier() || path.get("right").isIdentifier();
+  const leftIsDecimal = knownDecimalNodes.has(left) || argumentIsIdentifier;
+  const rightIsDecimal = knownDecimalNodes.has(right) || argumentIsIdentifier;
 
   if (earlyReturn([!leftIsDecimal && !rightIsDecimal])) {
     return;
@@ -29,7 +39,8 @@ const replaceWithDecimalExpression = (t, knownDecimalNodes) => (path) => {
 
   const member = t.memberExpression(left, t.identifier(opToName[operator]));
 
-  const newNode = t.callExpression(member, [right]);
+  const newNode = t.callExpression(member, [right])
+
 
   knownDecimalNodes.add(newNode);
 

--- a/transforms/shared.js
+++ b/transforms/shared.js
@@ -107,8 +107,8 @@ export const passesGeneralChecks = (path, knownDecimalNodes, opToName) => {
 
   const { left, right, operator } = path.node;
 
-  const leftIsDecimal = knownDecimalNodes.has(left);
-  const rightIsDecimal = knownDecimalNodes.has(right);
+  const leftIsDecimal = knownDecimalNodes.has(left) || path.get("left").isIdentifier();
+  const rightIsDecimal = knownDecimalNodes.has(right) || path.get("right").isIdentifier();
 
   if (leftIsDecimal !== rightIsDecimal) {
     throw path.buildCodeFrameError(

--- a/transforms/shared.js
+++ b/transforms/shared.js
@@ -27,6 +27,10 @@ const coerceConstructorArg = (path, t) => {
     return t.StringLiteral(first.node.value);
   }
 
+  if (first.isIdentifier()) {
+    return t.callExpression(t.identifier('wrappedConstructorIdentifier'), [first.node])
+  }
+
   return first.node;
 };
 


### PR DESCRIPTION
This deals with the issue where using an identifier in a `BinaryExpression` would cause the mixed types warning to throw as well as cases where an identifier is passed to a constructor. 

For instance the following code would throw regardless of the value assigned to `n`:

```
let n = 14.4m
n + 10m;
```

I originally considered passing identifiers through and intervening in a proxy, but the way we chain methods when using the Decimal/Big libraries meant that order in the BinaryExpression would matter and there was no effective way to intervene when the identifier was on the left. That is, in `Decimal128` mode, the code above transforms to:

```
var nm = n.add(Decimal128("10"));
```

I have also applied the same pattern to calls to the `Decimal` constructor so that arguments are coerced as we expect.