### PR TITLE
Adds not-equal ops

### DIFF
--- a/src/runner/patch-library.js
+++ b/src/runner/patch-library.js
@@ -21,3 +21,18 @@ export const typeofCheck = (arg) => {
 
   return typeof arg;
 };
+
+export const invertEquals = (left, right) => {
+  if (left instanceof Decimal128 || right instanceof Decimal128) {
+    return Decimal128(left).eq(right);
+  }
+
+  if (left instanceof Big || right instanceof Big) {
+    return Big(left).eq(right);
+  }
+
+  return left != right;
+};
+
+export const invertTypeCheckAndCallEq = (left, right) =>
+  !typeCheckAndCallEq(left, right);

--- a/src/runner/patches.js
+++ b/src/runner/patches.js
@@ -1,7 +1,12 @@
 /* global Big, Decimal */
 
 import { BIG_DECIMAL, DECIMAL_128 } from "../constants.js";
-import { typeCheckAndCallEq, typeofCheck } from "./patch-library.js"
+import {
+  invertEquals,
+  invertTypeCheckAndCallEq,
+  typeCheckAndCallEq,
+  typeofCheck,
+} from "./patch-library.js";
 import { checkAndInitMathHandlers } from "./patch-math.js";
 import { roundImpl } from "./patch-round.js";
 import {
@@ -20,3 +25,5 @@ Decimal.round = new Proxy(
 
 Decimal.tripleEquals = typeCheckAndCallEq;
 Decimal.typeof = typeofCheck;
+Decimal.notEquals = invertEquals;
+Decimal.notTripleEquals = invertTypeCheckAndCallEq;

--- a/transforms/shared.js
+++ b/transforms/shared.js
@@ -276,6 +276,8 @@ export const sharedMixedOps = {
 
 export const specialCaseOps = {
   "===": "tripleEquals",
+  "!=": "notEquals",
+  "!==": "notTripleEquals",
 };
 
 export const unaryDecimalFns = {


### PR DESCRIPTION
The tin remains the soure of truth. Now `!=` and `!==` work, both with and without variables. 