### PR TITLE
Add ability to use Decimal as key

### DIFF
--- a/src/runner/patch-prototype.js
+++ b/src/runner/patch-prototype.js
@@ -66,11 +66,9 @@ const coerceValue = (patchedMethodName, v) => {
   `);
 };
 
-export const protoPatch =
+export const decProtoPatch =
   (implName, patchedMethodName) =>
   (target, decimal, [val, options = {}]) => {
-    console.log("^^^", implName, decimal, val, options);
-
     const { roundingMode, errorMessage } = options;
 
     const call = roundingMode
@@ -94,3 +92,17 @@ export const protoPatch =
       throw new err.constructor(err);
     }
   };
+
+export const decToStringMap = (target, thisArg, [key, val]) => {
+  const isDecInstance = (a) => a instanceof Decimal128 || a instanceof Big;
+
+  const convertedKey = isDecInstance(key) ? `${key.toString()}m` : key;
+  return target.call(thisArg, convertedKey, val);
+};
+
+export const decToStringSet = (target, thisArg, [val]) => {
+  const isDecInstance = (a) => a instanceof Decimal128 || a instanceof Big;
+
+  const convertedVal = isDecInstance(val) ? `${val.toString()}m` : val;
+  return target.call(thisArg, convertedVal);
+};

--- a/src/runner/patches.js
+++ b/src/runner/patches.js
@@ -19,7 +19,11 @@ import {
   subtractImpl,
 } from "./patch-binary.js";
 import { powImpl } from "./patch-pow.js";
-import { protoPatch } from "./patch-prototype.js";
+import {
+  decProtoPatch,
+  decToStringMap,
+  decToStringSet,
+} from "./patch-prototype.js";
 import { roundImpl } from "./patch-round.js";
 import {
   createUnaryHandler,
@@ -33,6 +37,26 @@ import {
 
 checkAndInitMathHandlers(createUnaryHandler, createNaryHandler);
 initUnsupportedMathHandlers(throwsOnDecimalArg);
+
+Map.prototype.set = new Proxy(
+  Map.prototype.set,
+  createPrototypeHandler(decToStringMap)
+);
+
+Map.prototype.get = new Proxy(
+  Map.prototype.get,
+  createPrototypeHandler(decToStringMap)
+);
+
+Set.prototype.add = new Proxy(
+  Set.prototype.add,
+  createPrototypeHandler(decToStringSet)
+);
+
+Set.prototype.has = new Proxy(
+  Set.prototype.has,
+  createPrototypeHandler(decToStringSet)
+);
 
 Decimal.add = new Proxy(
   decimalOnlyBaseFn("Decimal.add"),
@@ -79,30 +103,30 @@ Decimal128.prototype.toLocaleString = unimplementedButIntended;
 
 Decimal128.prototype.toFixed = new Proxy(
   Decimal128.prototype.toFixed,
-  createPrototypeHandler(protoPatch(DECIMAL_128, "toFixed"))
+  createPrototypeHandler(decProtoPatch(DECIMAL_128, "toFixed"))
 );
 
 Big.prototype.toFixed = new Proxy(
   Big.prototype.toFixed,
-  createPrototypeHandler(protoPatch(BIG_DECIMAL, "toFixed"))
+  createPrototypeHandler(decProtoPatch(BIG_DECIMAL, "toFixed"))
 );
 
 Decimal128.prototype.toExponential = new Proxy(
   Decimal128.prototype.toExponential,
-  createPrototypeHandler(protoPatch(DECIMAL_128, "toExponential"))
+  createPrototypeHandler(decProtoPatch(DECIMAL_128, "toExponential"))
 );
 
 Big.prototype.toExponential = new Proxy(
   Big.prototype.toExponential,
-  createPrototypeHandler(protoPatch(BIG_DECIMAL, "toExponential"))
+  createPrototypeHandler(decProtoPatch(BIG_DECIMAL, "toExponential"))
 );
 
 Decimal128.prototype.toPrecision = new Proxy(
   Decimal128.prototype.toPrecision,
-  createPrototypeHandler(protoPatch(DECIMAL_128, "toPrecision"))
+  createPrototypeHandler(decProtoPatch(DECIMAL_128, "toPrecision"))
 );
 
 Big.prototype.toPrecision = new Proxy(
   Big.prototype.toPrecision,
-  createPrototypeHandler(protoPatch(BIG_DECIMAL, "toPrecision"))
+  createPrototypeHandler(decProtoPatch(BIG_DECIMAL, "toPrecision"))
 );

--- a/transforms/bigdec.js
+++ b/transforms/bigdec.js
@@ -11,6 +11,7 @@ import {
   earlyReturn,
   handleCallExpression,
   handleLogicalExpression,
+  handleMemberExpression,
   handleMixedOps,
   handleSingleTypeOps,
   handleSpecialCaseOps,
@@ -91,6 +92,9 @@ export default function (babel) {
       DecimalLiteral: replaceWithDecimal(t, implementationIdentifier),
       LogicalExpression: {
         exit: handleLogicalExpression(t, knownDecimalNodes),
+      },
+      MemberExpression: {
+        exit: handleMemberExpression(t, knownDecimalNodes),
       },
       NewExpression: checkAndThrowForDecimal,
       UnaryExpression: {

--- a/transforms/dec128.js
+++ b/transforms/dec128.js
@@ -11,6 +11,7 @@ import {
   earlyReturn,
   handleCallExpression,
   handleLogicalExpression,
+  handleMemberExpression,
   handleMixedOps,
   handleSpecialCaseOps,
   handleSingleTypeOps,
@@ -95,6 +96,9 @@ export default function (babel) {
       DecimalLiteral: replaceWithDecimal(t, implementationIdentifier),
       LogicalExpression: {
         exit: handleLogicalExpression(t, knownDecimalNodes),
+      },
+      MemberExpression: {
+        exit: handleMemberExpression(t, knownDecimalNodes),
       },
       NewExpression: checkAndThrowForDecimal,
       UnaryExpression: {

--- a/transforms/shared.js
+++ b/transforms/shared.js
@@ -336,6 +336,27 @@ export const handleLogicalExpression = (t, knownDecimalNodes) => (path) => {
   path.skip();
 };
 
+export const handleMemberExpression = (t, knownDecimalNodes) => (path) => {
+  const object = path.get("object");
+  const property = path.get("property");
+
+  if (!knownDecimalNodes.has(property.node)) {
+    return;
+  }
+
+  const newProperty = t.memberExpression(
+    property.node,
+    t.Identifier("toString")
+  );
+  const newCall = t.callExpression(newProperty, []);
+  const newNode = t.MemberExpression(object.node, newCall, true);
+
+  knownDecimalNodes.add(newNode);
+
+  path.replaceWith(newNode);
+  path.skip();
+};
+
 export const earlyReturn = (conditions) => {
   return conditions.every(Boolean);
 };


### PR DESCRIPTION
Adds support for Decimal values as keys to plain objects and `Map`s, as well as values for `Set`s.