### PR TITLE
Fix bug where adding LogicalExpression to knownDecimalNodes ...

### DIFF
--- a/transforms/bigdec.js
+++ b/transforms/bigdec.js
@@ -62,7 +62,7 @@ const replaceWithBinaryDecimalExpression = (t, knownDecimalNodes) => (path) => {
     : handleSingleTypeOps(t, knownDecimalNodes, path, opToName);
 
   if (includesIdentifierArgument) {
-    createIdentifierNode(t, knownDecimalNodes, path, transformations);
+    createIdentifierNode(t, path, transformations);
     return;
   }
 
@@ -95,9 +95,6 @@ export default function (babel) {
       DecimalLiteral: replaceWithDecimal(t, implementationIdentifier),
       LogicalExpression: {
         exit: handleLogicalExpression(t, knownDecimalNodes),
-      },
-      MemberExpression: {
-        exit: handleMemberExpression(t, knownDecimalNodes),
       },
       NewExpression: checkAndThrowForDecimal,
       UnaryExpression: {

--- a/transforms/dec128.js
+++ b/transforms/dec128.js
@@ -100,9 +100,6 @@ export default function (babel) {
       LogicalExpression: {
         exit: handleLogicalExpression(t, knownDecimalNodes),
       },
-      MemberExpression: {
-        exit: handleMemberExpression(t, knownDecimalNodes),
-      },
       NewExpression: checkAndThrowForDecimal,
       UnaryExpression: {
         exit: replaceWithUnaryDecimalExpression(t, knownDecimalNodes),


### PR DESCRIPTION
… caused unexpected behavior. Also cleans up some spots where we don't need to add identifier nodes to `knownDecimalNodes` and removes `MemberExpression` handler becuse engine code can handle it.